### PR TITLE
Fix rendering of arcTo when a scale is applied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 coverage
+.vscode

--- a/context.js
+++ b/context.js
@@ -1015,11 +1015,14 @@ export default (function () {
             largeArcFlag = diff > Math.PI ? 1 : 0;
         }
 
+        var scaleX = Math.hypot(this.__transformMatrix.a, this.__transformMatrix.b);
+        var scaleY = Math.hypot(this.__transformMatrix.c, this.__transformMatrix.d);
+
         this.lineTo(startX, startY);
         this.__addPathCommand(format("A {rx} {ry} {xAxisRotation} {largeArcFlag} {sweepFlag} {endX} {endY}",
             {
-                rx:radius,
-                ry:radius,
+                rx:radius * scaleX,
+                ry:radius * scaleY,
                 xAxisRotation:0,
                 largeArcFlag:largeArcFlag,
                 sweepFlag:sweepFlag,

--- a/test/index.js
+++ b/test/index.js
@@ -2,6 +2,7 @@ import {Element} from '../index'
 import arc from './tests/arc'
 import arcTo from './tests/arcTo'
 import arcTo2 from './tests/arcTo2'
+import arcToScaled from './tests/arcToScaled'
 import emptyArc from './tests/emptyArc'
 import fillstyle from './tests/fillstyle'
 import globalAlpha from './tests/globalalpha'
@@ -22,6 +23,7 @@ const tests = [
     arc,
     arcTo,
     arcTo2,
+    arcToScaled,
     emptyArc,
     fillstyle,
     globalAlpha,

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -3,6 +3,7 @@ import { expect } from 'chai'
 import arc from './tests/arc'
 import arcTo from './tests/arcTo'
 import arcTo2 from './tests/arcTo2'
+import arcToScaled from './tests/arcToScaled'
 import emptyArc from './tests/emptyArc'
 import fillstyle from './tests/fillstyle'
 import globalAlpha from './tests/globalalpha'
@@ -23,6 +24,7 @@ const tests = {
     arc,
     arcTo,
     arcTo2,
+    arcToScaled,
     emptyArc,
     fillstyle,
     globalAlpha,

--- a/test/tests/arcToScaled.js
+++ b/test/tests/arcToScaled.js
@@ -1,0 +1,13 @@
+export default function arcToScaled(ctx) {
+  ctx.scale(2, 0.5);
+  ctx.beginPath();
+  ctx.moveTo(100, 50);
+  ctx.arcTo(150, 50, 150, 100, 50);
+  ctx.arcTo(150, 150, 100, 150, 50);
+  ctx.arcTo(50, 150, 50, 100, 50);
+  ctx.arcTo(50, 50, 100, 50, 50);
+
+  // Reset the scale before we stroke since SVG stroke is not scaled.
+  ctx.setTransform(1, 0, 0, 1, 0, 0);
+  ctx.stroke();
+};


### PR DESCRIPTION
`arc` and `arcTo` were not rendering correctly when the scale is anything other than 1. The scale should be applied to the radius to get a consistent result.

Because the scale is not applied to the stroke either in the SVG version, in the test-case the scale must be removed before stroking in order to prevent an unrelated difference.

`arcTo` Before:
<img width="1118" alt="Screen Shot 2022-07-14 at 8 14 36 PM" src="https://user-images.githubusercontent.com/161640/179143030-70fc9c52-d3f0-42d8-8ef7-48f8888ccc92.png">
`arcTo` After:
<img width="1144" alt="Screen Shot 2022-07-14 at 8 13 26 PM" src="https://user-images.githubusercontent.com/161640/179143039-c71fa22e-a31f-4abd-8ec0-9bf052413ef6.png">
`arc` before (with scale applied):
<img width="1097" alt="Screen Shot 2022-07-14 at 8 15 04 PM" src="https://user-images.githubusercontent.com/161640/179143020-e7c9ea24-4078-4b1f-a267-ba128e7f96a5.png">