### PR TITLE
Ellipse translate and rotate problem

### DIFF
--- a/context.js
+++ b/context.js
@@ -1071,8 +1071,14 @@ export default (function () {
         } else {
             largeArcFlag = diff > Math.PI ? 1 : 0;
         }
-        
-        this.lineTo(startX / scaleX, startY / scaleY);
+
+        // Transform is already applied, so temporarily remove since lineTo
+        // will apply it again.
+        var currentTransform = this.__transformMatrix;
+        this.resetTransform();
+        this.lineTo(startX, startY);
+        this.__transformMatrix = currentTransform;
+
         this.__addPathCommand(format("A {rx} {ry} {xAxisRotation} {largeArcFlag} {sweepFlag} {endX} {endY}",
             {
                 rx:radiusX, 

--- a/context.js
+++ b/context.js
@@ -1038,12 +1038,13 @@ export default (function () {
             return;
         }
 
-        x = this.__matrixTransform(x, y).x;
-        y = this.__matrixTransform(x, y).y;
-        var scaleX = Math.hypot(this.__transformMatrix.a, this.__transformMatrix.b);
-        var scaleY = Math.hypot(this.__transformMatrix.c, this.__transformMatrix.d);
-        radiusX = radiusX * scaleX;
-        radiusY = radiusY * scaleY;
+        var transformedCenter = this.__matrixTransform(x, y);
+        x = transformedCenter.x;
+        y = transformedCenter.y;
+        var scale = this.__getTransformScale();
+        radiusX = radiusX * scale.x;
+        radiusY = radiusY * scale.y;
+        rotation = rotation + this.__getTransformRotation()
 
         startAngle = startAngle % (2*Math.PI);
         endAngle = endAngle % (2*Math.PI);
@@ -1336,6 +1337,25 @@ export default (function () {
 
     Context.prototype.__matrixTransform = function(x, y) {
         return new DOMPoint(x, y).matrixTransform(this.__transformMatrix)
+    }
+
+    /**
+     * 
+     * @returns The scale component of the transform matrix as {x,y}.
+     */
+    Context.prototype.__getTransformScale = function() {
+        return {
+            x: Math.hypot(this.__transformMatrix.a, this.__transformMatrix.b),
+            y: Math.hypot(this.__transformMatrix.c, this.__transformMatrix.d)
+        };
+    }
+
+    /**
+     * 
+     * @returns The rotation component of the transform matrix in radians.
+     */
+    Context.prototype.__getTransformRotation = function() {
+        return Math.atan2(this.__transformMatrix.b, this.__transformMatrix.a);
     }
 
     /**

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ import arcTo from './tests/arcTo'
 import arcTo2 from './tests/arcTo2'
 import emptyArc from './tests/emptyArc'
 import ellipse from './tests/ellipse'
+import ellipse2 from './tests/ellipse2'
 import fillstyle from './tests/fillstyle'
 import globalAlpha from './tests/globalalpha'
 import gradient from './tests/gradient'
@@ -25,6 +26,7 @@ const tests = [
     arcTo2,
     emptyArc,
     ellipse,
+    ellipse2,
     fillstyle,
     globalAlpha,
     gradient,

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -5,6 +5,7 @@ import arcTo from './tests/arcTo'
 import arcTo2 from './tests/arcTo2'
 import emptyArc from './tests/emptyArc'
 import ellipse from './tests/ellipse'
+import ellipse2 from './tests/ellipse2'
 import fillstyle from './tests/fillstyle'
 import globalAlpha from './tests/globalalpha'
 import gradient from './tests/gradient'
@@ -26,6 +27,7 @@ const tests = {
     arcTo2,
     emptyArc,
     ellipse,
+    ellipse2,
     fillstyle,
     globalAlpha,
     gradient,

--- a/test/tests/ellipse2.js
+++ b/test/tests/ellipse2.js
@@ -1,0 +1,32 @@
+
+export default function ellipse2(ctx) {
+    // Draw a cylinder using ellipses and lines.
+    var w = 100, h = 100, rx = 50, ry = 10;
+    var scaleX = 1.5, scaleY = 2.5;
+
+    ctx.scale(scaleX, scaleY);
+    ctx.translate(100, 75);
+
+    ctx.beginPath();
+    ctx.moveTo(-w / 2, -h / 2 + ry);
+    // upper arc top
+    ctx.ellipse(0, -h / 2 + ry, rx, ry, Math.PI, 0, Math.PI, 0);
+    ctx.moveTo(-w / 2, -h / 2 + ry);
+    // upper arc bottom
+    ctx.ellipse(0, -h / 2 + ry, rx, ry, Math.PI, 0, Math.PI, 1);
+    ctx.moveTo(-w / 2, -h / 2 + ry);
+    // left line
+    ctx.lineTo(-w / 2, + h / 2 - ry);
+    // lower arc
+    ctx.ellipse(0, h / 2 - ry, rx, ry, Math.PI, 0, Math.PI, 1);
+    // right line
+    ctx.lineTo(w / 2, -h / 2 + ry);
+    ctx.moveTo(-w / 2, -h / 2 + ry);
+    ctx.closePath();
+
+    // Remove scale before stroking because the SVG conversion is not correctly
+    // scaling the stroke as well. Without this the pixel differences are too
+    // high.
+    ctx.scale(1 / scaleX, 1 / scaleY);
+    ctx.stroke();
+};

--- a/test/tests/ellipse2.js
+++ b/test/tests/ellipse2.js
@@ -2,10 +2,11 @@
 export default function ellipse2(ctx) {
     // Draw a cylinder using ellipses and lines.
     var w = 100, h = 100, rx = 50, ry = 10;
-    var scaleX = 1.5, scaleY = 2.5;
+    var scaleX = 1.5, scaleY = 1.2;
 
+    ctx.rotate(Math.PI / 10);
     ctx.scale(scaleX, scaleY);
-    ctx.translate(100, 75);
+    ctx.translate(200, 25);
 
     ctx.beginPath();
     ctx.moveTo(-w / 2, -h / 2 + ry);
@@ -27,6 +28,6 @@ export default function ellipse2(ctx) {
     // Remove scale before stroking because the SVG conversion is not correctly
     // scaling the stroke as well. Without this the pixel differences are too
     // high.
-    ctx.scale(1 / scaleX, 1 / scaleY);
+    ctx.resetTransform();
     ctx.stroke();
 };


### PR DESCRIPTION
The ellipse conversion did not work when a rotation or translation was applied to the canvas.

Before (just a translation): 
<img width="1111" alt="Screen Shot 2022-07-17 at 9 07 37 AM" src="https://user-images.githubusercontent.com/161640/179416468-f79ca3e1-c320-4b21-b4bd-dd263a530abe.png">

After (rotation and translation):
<img width="1090" alt="Screen Shot 2022-07-17 at 9 58 19 AM" src="https://user-images.githubusercontent.com/161640/179416465-49ef8751-af25-4a5e-a47b-5f4c8dedc4bc.png">

