### PR TITLE
Scale lineWidth

### DIFF
--- a/context.js
+++ b/context.js
@@ -1071,8 +1071,14 @@ export default (function () {
         } else {
             largeArcFlag = diff > Math.PI ? 1 : 0;
         }
-        
-        this.lineTo(startX / scaleX, startY / scaleY);
+
+        // Transform is already applied, so temporarily remove since lineTo
+        // will apply it again.
+        var currentTransform = this.__transformMatrix;
+        this.resetTransform();
+        this.lineTo(startX, startY);
+        this.__transformMatrix = currentTransform;
+
         this.__addPathCommand(format("A {rx} {ry} {xAxisRotation} {largeArcFlag} {sweepFlag} {endX} {endY}",
             {
                 rx:radiusX, 

--- a/context.js
+++ b/context.js
@@ -1038,12 +1038,13 @@ export default (function () {
             return;
         }
 
-        x = this.__matrixTransform(x, y).x;
-        y = this.__matrixTransform(x, y).y;
-        var scaleX = Math.hypot(this.__transformMatrix.a, this.__transformMatrix.b);
-        var scaleY = Math.hypot(this.__transformMatrix.c, this.__transformMatrix.d);
-        radiusX = radiusX * scaleX;
-        radiusY = radiusY * scaleY;
+        var transformedCenter = this.__matrixTransform(x, y);
+        x = transformedCenter.x;
+        y = transformedCenter.y;
+        var scale = this.__getTransformScale();
+        radiusX = radiusX * scale.x;
+        radiusY = radiusY * scale.y;
+        rotation = rotation + this.__getTransformRotation()
 
         startAngle = startAngle % (2*Math.PI);
         endAngle = endAngle % (2*Math.PI);
@@ -1336,6 +1337,25 @@ export default (function () {
 
     Context.prototype.__matrixTransform = function(x, y) {
         return new DOMPoint(x, y).matrixTransform(this.__transformMatrix)
+    }
+
+    /**
+     * 
+     * @returns The scale component of the transform matrix as {x,y}.
+     */
+    Context.prototype.__getTransformScale = function() {
+        return {
+            x: Math.hypot(this.__transformMatrix.a, this.__transformMatrix.b),
+            y: Math.hypot(this.__transformMatrix.c, this.__transformMatrix.d)
+        };
+    }
+
+    /**
+     * 
+     * @returns The rotation component of the transform matrix in radians.
+     */
+    Context.prototype.__getTransformRotation = function() {
+        return Math.atan2(this.__transformMatrix.b, this.__transformMatrix.a);
     }
 
     /**

--- a/context.js
+++ b/context.js
@@ -433,6 +433,9 @@ export default (function () {
                                  //fill-opacity or stroke-opacity has already been set by stroke or fill.
                                 continue;
                             }
+                        } else if (keys[i] === 'lineWidth') {
+                            var scale = this.__getTransformScale();
+                            value = value * Math.max(scale.x, scale.y);
                         }
                         //otherwise only update attribute if right type, and not svg default
                         currentElement.setAttribute(attr, value);

--- a/test/index.js
+++ b/test/index.js
@@ -4,6 +4,7 @@ import arcTo from './tests/arcTo'
 import arcTo2 from './tests/arcTo2'
 import emptyArc from './tests/emptyArc'
 import ellipse from './tests/ellipse'
+import ellipse2 from './tests/ellipse2'
 import fillstyle from './tests/fillstyle'
 import globalAlpha from './tests/globalalpha'
 import gradient from './tests/gradient'
@@ -25,6 +26,7 @@ const tests = [
     arcTo2,
     emptyArc,
     ellipse,
+    ellipse2,
     fillstyle,
     globalAlpha,
     gradient,

--- a/test/index.js
+++ b/test/index.js
@@ -10,6 +10,7 @@ import globalAlpha from './tests/globalalpha'
 import gradient from './tests/gradient'
 import linecap from './tests/linecap'
 import linewidth from './tests/linewidth'
+import scaledLine from './tests/scaledLine'
 import rgba from './tests/rgba'
 import rotate from './tests/rotate'
 import saveandrestore from './tests/saveandrestore'
@@ -32,6 +33,7 @@ const tests = [
     gradient,
     linecap,
     linewidth,
+    scaledLine,
     rgba,
     rotate,
     saveandrestore,

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -11,6 +11,7 @@ import globalAlpha from './tests/globalalpha'
 import gradient from './tests/gradient'
 import linecap from './tests/linecap'
 import linewidth from './tests/linewidth'
+import scaledLine from './tests/scaledLine'
 import rgba from './tests/rgba'
 import rotate from './tests/rotate'
 import saveandrestore from './tests/saveandrestore'
@@ -33,6 +34,7 @@ const tests = {
     gradient,
     linecap,
     linewidth,
+    scaledLine,
     rgba,
     rotate,
     saveandrestore,

--- a/test/rendering.test.js
+++ b/test/rendering.test.js
@@ -5,6 +5,7 @@ import arcTo from './tests/arcTo'
 import arcTo2 from './tests/arcTo2'
 import emptyArc from './tests/emptyArc'
 import ellipse from './tests/ellipse'
+import ellipse2 from './tests/ellipse2'
 import fillstyle from './tests/fillstyle'
 import globalAlpha from './tests/globalalpha'
 import gradient from './tests/gradient'
@@ -26,6 +27,7 @@ const tests = {
     arcTo2,
     emptyArc,
     ellipse,
+    ellipse2,
     fillstyle,
     globalAlpha,
     gradient,

--- a/test/tests/ellipse2.js
+++ b/test/tests/ellipse2.js
@@ -1,0 +1,32 @@
+
+export default function ellipse2(ctx) {
+    // Draw a cylinder using ellipses and lines.
+    var w = 100, h = 100, rx = 50, ry = 10;
+    var scaleX = 1.5, scaleY = 2.5;
+
+    ctx.scale(scaleX, scaleY);
+    ctx.translate(100, 75);
+
+    ctx.beginPath();
+    ctx.moveTo(-w / 2, -h / 2 + ry);
+    // upper arc top
+    ctx.ellipse(0, -h / 2 + ry, rx, ry, Math.PI, 0, Math.PI, 0);
+    ctx.moveTo(-w / 2, -h / 2 + ry);
+    // upper arc bottom
+    ctx.ellipse(0, -h / 2 + ry, rx, ry, Math.PI, 0, Math.PI, 1);
+    ctx.moveTo(-w / 2, -h / 2 + ry);
+    // left line
+    ctx.lineTo(-w / 2, + h / 2 - ry);
+    // lower arc
+    ctx.ellipse(0, h / 2 - ry, rx, ry, Math.PI, 0, Math.PI, 1);
+    // right line
+    ctx.lineTo(w / 2, -h / 2 + ry);
+    ctx.moveTo(-w / 2, -h / 2 + ry);
+    ctx.closePath();
+
+    // Remove scale before stroking because the SVG conversion is not correctly
+    // scaling the stroke as well. Without this the pixel differences are too
+    // high.
+    ctx.scale(1 / scaleX, 1 / scaleY);
+    ctx.stroke();
+};

--- a/test/tests/ellipse2.js
+++ b/test/tests/ellipse2.js
@@ -2,10 +2,11 @@
 export default function ellipse2(ctx) {
     // Draw a cylinder using ellipses and lines.
     var w = 100, h = 100, rx = 50, ry = 10;
-    var scaleX = 1.5, scaleY = 2.5;
+    var scaleX = 1.5, scaleY = 1.2;
 
+    ctx.rotate(Math.PI / 10);
     ctx.scale(scaleX, scaleY);
-    ctx.translate(100, 75);
+    ctx.translate(200, 25);
 
     ctx.beginPath();
     ctx.moveTo(-w / 2, -h / 2 + ry);
@@ -27,6 +28,6 @@ export default function ellipse2(ctx) {
     // Remove scale before stroking because the SVG conversion is not correctly
     // scaling the stroke as well. Without this the pixel differences are too
     // high.
-    ctx.scale(1 / scaleX, 1 / scaleY);
+    ctx.resetTransform();
     ctx.stroke();
 };

--- a/test/tests/scaledLine.js
+++ b/test/tests/scaledLine.js
@@ -1,0 +1,10 @@
+export default function scaledLine(ctx) {
+  ctx.scale(1.5, 1.5);
+  for (var i = 0; i < 10; i++){
+      ctx.lineWidth = 1+i;
+      ctx.beginPath();
+      ctx.moveTo(5+i*14,5);
+      ctx.lineTo(5+i*14,140);
+      ctx.stroke();
+  }
+};


### PR DESCRIPTION
When a scale is applied to the canvas it was not affecting the `lineWidth`. 

This fix will only work if scaling is proportional, i.e. X and Y axes are scaled the same.

(This PR is currently built on top of https://github.com/zenozeng/svgcanvas/pull/19 so it can re-use the new `__getTransformScale` function.)

Before:
<img width="1088" alt="Screen Shot 2022-07-17 at 10 52 26 AM" src="https://user-images.githubusercontent.com/161640/179419636-5c1c72f9-0026-4024-bbbb-94ed998a01ef.png">

After:
<img width="1092" alt="Screen Shot 2022-07-17 at 11 26 19 AM" src="https://user-images.githubusercontent.com/161640/179419645-09974f4c-4063-4832-ac2c-e1a4c9fb9aa5.png">

