### PR TITLE
Arc-related fix for NaN arguments

### DIFF
--- a/context.js
+++ b/context.js
@@ -989,6 +989,13 @@ export default (function () {
      *  Arc command!
      */
     Context.prototype.arc = function (x, y, radius, startAngle, endAngle, counterClockwise) {
+        x = x || 0;
+        y = y || 0;
+        radius = radius || 0;
+        startAngle = startAngle || 0;
+        endAngle = endAngle || 0;
+        counterClockwise = counterClockwise || 0;
+
         // in canvas no circle is drawn if no angle is provided.
         if (startAngle === endAngle) {
             return;
@@ -1021,7 +1028,7 @@ export default (function () {
         var scaleX = Math.hypot(this.__transformMatrix.a, this.__transformMatrix.b);
         var scaleY = Math.hypot(this.__transformMatrix.c, this.__transformMatrix.d);
 
-        this.lineTo(startX, startY);
+        this.lineTo(startX || 0, startY || 0);
         this.__addPathCommand(format("A {rx} {ry} {xAxisRotation} {largeArcFlag} {sweepFlag} {endX} {endY}",
             {
                 rx:radius * scaleX,

--- a/context.js
+++ b/context.js
@@ -1088,11 +1088,11 @@ export default (function () {
 
         this.__addPathCommand(format("A {rx} {ry} {xAxisRotation} {largeArcFlag} {sweepFlag} {endX} {endY}",
             {
-                rx:radiusX, 
-                ry:radiusY, 
-                xAxisRotation:rotation*(180/Math.PI), 
-                largeArcFlag:largeArcFlag, 
-                sweepFlag:sweepFlag, 
+                rx:radiusX,
+                ry:radiusY,
+                xAxisRotation:rotation*(180/Math.PI),
+                largeArcFlag:largeArcFlag,
+                sweepFlag:sweepFlag,
                 endX:endX,
                 endY:endY
             }));
@@ -1326,7 +1326,7 @@ export default (function () {
      * @see https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/translate
      */
     Context.prototype.translate = function (x, y) {
-        const matrix = this.getTransform().translate(x, y);
+        const matrix = this.getTransform().translate(x || 0, y || 0);
         this.setTransform(matrix);
     };
 
@@ -1346,7 +1346,7 @@ export default (function () {
     }
 
     /**
-     * 
+     *
      * @returns The scale component of the transform matrix as {x,y}.
      */
     Context.prototype.__getTransformScale = function() {
@@ -1357,7 +1357,7 @@ export default (function () {
     }
 
     /**
-     * 
+     *
      * @returns The rotation component of the transform matrix in radians.
      */
     Context.prototype.__getTransformRotation = function() {

--- a/context.js
+++ b/context.js
@@ -412,7 +412,8 @@ export default (function () {
                         currentElement.setAttribute(style.apply, format("url(#{id})", {id:value.__root.getAttribute("id")}));
                     }
                 }
-                else if (value instanceof CanvasGradient) {
+                else if (value instanceof CanvasGradient || value.constructor.name === 'CanvasGradient') {
+                    console.log(value);
                     //gradient
                     currentElement.setAttribute(style.apply, format("url(#{id})", {id:value.__root.getAttribute("id")}));
                 } else if (style.apply.indexOf(type)!==-1 && style.svg !== value) {

--- a/context.js
+++ b/context.js
@@ -396,18 +396,21 @@ export default (function () {
             value = this[keys[i]];
             if (style.apply) {
                 //is this a gradient or pattern?
-                if (value instanceof CanvasPattern) {
-                    //pattern
-                    if (value.__ctx) {
-                        //copy over defs
-                        for(nodeIndex = 0; nodeIndex < value.__ctx.__defs.childNodes.length; nodeIndex++){
-                          node = value.__ctx.__defs.childNodes[nodeIndex];
-                          id = node.getAttribute("id");
-                          this.__ids[id] = id;
-                          this.__defs.appendChild(node);
+                if (value instanceof CanvasPattern || value.constructor.name === 'CanvasPattern') {
+                    if (value.image) { //MODIFIED
+                        value = this.createPattern(value.image, null); //HINT pulls in original image ref from Konva
+                        //pattern
+                        if (value.__ctx) {
+                            //copy over defs
+                            for(nodeIndex = 0; nodeIndex < value.__ctx.__defs.childNodes.length; nodeIndex++){
+                              node = value.__ctx.__defs.childNodes[nodeIndex];
+                              id = node.getAttribute("id");
+                              this.__ids[id] = id;
+                              this.__defs.appendChild(node);
+                            }
                         }
+                        currentElement.setAttribute(style.apply, format("url(#{id})", {id:value.__root.getAttribute("id")}));
                     }
-                    currentElement.setAttribute(style.apply, format("url(#{id})", {id:value.__root.getAttribute("id")}));
                 }
                 else if (value instanceof CanvasGradient) {
                     //gradient

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svgcanvas",
-  "version": "2.2.2",
+  "version": "2.5.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "svgcanvas",
-      "version": "2.2.2",
+      "version": "2.5.0",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "svgcanvas",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "svgcanvas",
-      "version": "2.5.0",
+      "version": "2.5.1",
       "license": "MIT",
       "devDependencies": {
         "@rollup/plugin-commonjs": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "svgcanvas",
+  "name": "@symbolic/svgcanvas",
   "version": "2.5.0",
-  "description": "svgcanvas",
+  "description": "@symbolic/svgcanvas",
   "main": "dist/svgcanvas.js",
   "scripts": {
     "watch": "rollup -c -w",
@@ -9,16 +9,11 @@
     "prepublishOnly": "npm run build",
     "test": "karma start"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/zenozeng/svgcanvas.git"
-  },
   "keywords": [
     "canvas",
     "svg",
     "canvas2svg"
   ],
-  "author": "Zeno Zeng",
   "license": "MIT",
   "devDependencies": {
     "@rollup/plugin-commonjs": "^21.0.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@symbolic/svgcanvas",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "description": "@symbolic/svgcanvas",
   "main": "dist/svgcanvas.js",
   "scripts": {


### PR DESCRIPTION
**Purpose**: This is not intended to be a functional pull request, instead we needed to make this change for our purposes to support arcs in certain conditions. We thought creating the pull request would be helpful to see for maintainers to see the changes.

**Context**: We're using `react-konva` as our canvas engine when generating SVGs.

There seem to be two issues:
1. Context.prototype.translate
    * `x` and `y` parameters were `NaN` in some cases. Using `x || 0` seemed to be a reasonable hot-fix for us. It may be that this is a `react-konva` specific issue and other applications wouldn't be passing `NaN` as a translate argument, but this still might be worth adding anyway since the browser throws an error with `NaN`.
2. Context.prototype.arc
    * The issue was similar to `Context.prototype.translate`, but not as clear. We were able to address the `NaN` by adding blanket default fallback value of `|| 0` to most of the arguments.
