### PR TITLE
refactor: move xml serialization to utils, fix missed IE check before xml patch

### DIFF
--- a/context.js
+++ b/context.js
@@ -465,14 +465,8 @@ export default (function () {
      * @return serialized svg
      */
     Context.prototype.getSerializedSvg = function (fixNamedEntities) {
-        var serialized = new XMLSerializer().serializeToString(this.__root),
+        var serialized = utils.serializeXML(this.__root),
             keys, i, key, value, regexp, xmlns;
-
-        //IE search for a duplicate xmnls because they didn't implement setAttributeNS correctly
-        xmlns = /xmlns="http:\/\/www\.w3\.org\/2000\/svg".+xmlns="http:\/\/www\.w3\.org\/2000\/svg/gi;
-        if (xmlns.test(serialized)) {
-            serialized = serialized.replace('xmlns="http://www.w3.org/2000/svg','xmlns:xlink="http://www.w3.org/1999/xlink');
-        }
 
         if (fixNamedEntities) {
             keys = Object.keys(namedEntities);

--- a/image.js
+++ b/image.js
@@ -1,3 +1,5 @@
+import {serializeXML} from './utils';
+
 class ImageUtils {
 
     /**
@@ -22,21 +24,7 @@ class ImageUtils {
     }
     
     toDataURL(svgNode, width, height, type, encoderOptions, options) {
-        var xml = new XMLSerializer().serializeToString(svgNode);
-    
-        // documentMode is an IE-only property
-        // http://msdn.microsoft.com/en-us/library/ie/cc196988(v=vs.85).aspx
-        // http://stackoverflow.com/questions/10964966/detect-ie-version-prior-to-v9-in-javascript
-        var isIE = document.documentMode;
-    
-        if (isIE) {
-            // This is patch from canvas2svg
-            // IE search for a duplicate xmnls because they didn't implement setAttributeNS correctly
-            var xmlns = /xmlns="http:\/\/www\.w3\.org\/2000\/svg".+xmlns="http:\/\/www\.w3\.org\/2000\/svg/gi;
-            if(xmlns.test(xml)) {
-                xml = xml.replace('xmlns="http://www.w3.org/2000/svg','xmlns:xlink="http://www.w3.org/1999/xlink');
-            }
-        }
+        var xml = serializeXML(svgNode);
 
         if (!options) {
             options = {}

--- a/utils.js
+++ b/utils.js
@@ -16,4 +16,23 @@ function debug(...data) {
     }
 }
 
-export {toString, debug};
+function serializeXML(node) {
+    var xml = new XMLSerializer().serializeToString(node);
+
+    // documentMode is an IE-only property
+    // http://msdn.microsoft.com/en-us/library/ie/cc196988(v=vs.85).aspx
+    // http://stackoverflow.com/questions/10964966/detect-ie-version-prior-to-v9-in-javascript
+    var isIE = document.documentMode;
+
+    if (isIE) {
+        // This is patch from canvas2svg
+        // IE search for a duplicate xmnls because they didn't implement setAttributeNS correctly
+        var xmlns = /xmlns="http:\/\/www\.w3\.org\/2000\/svg".+xmlns="http:\/\/www\.w3\.org\/2000\/svg/gi;
+        if(xmlns.test(xml)) {
+            xml = xml.replace('xmlns="http://www.w3.org/2000/svg','xmlns:xlink="http://www.w3.org/1999/xlink');
+        }
+    }
+    return xml;
+}
+
+export {toString, debug, serializeXML};


### PR DESCRIPTION
There was no IE check before xml patch inside `context.js`, unlike `image.js`. I moved serialization and IE patch to utils, so this fix will only be applied for IE everywhere and there will be less duplicated code.

Not sure if `SVGCanvasElement.prototype.toObjectURL` also needs this IE fix, so i left it unchanged